### PR TITLE
新規作成ボタンをカタログ化

### DIFF
--- a/frontend/src/components/atoms/SignupButton.stories.tsx
+++ b/frontend/src/components/atoms/SignupButton.stories.tsx
@@ -1,0 +1,23 @@
+// src/components/SignupButton.stories.tsx
+
+import React from 'react';
+import { Meta, StoryFn } from '@storybook/react';
+import SignupButton from './SignupButton';
+
+// ストーリーブックのMeta情報を設定
+export default {
+  title: 'Components/SignupButton',  // Storybook内での表示名
+  component: SignupButton,          // 表示するコンポーネント
+  argTypes: {
+    onClick: { action: 'clicked' },  // クリックアクションをStorybookでトラッキング
+  },
+} as Meta;
+
+// Storyの定義
+const Template: StoryFn<typeof SignupButton> = (args) => <SignupButton {...args} />;
+// const Template: StoryFn<typeof LoginButton> = (args) => (
+// コンポーネントの例
+export const Default = Template.bind({});
+Default.args = {
+  onClick: () => console.log('新規登録ボタンがクリックされました'),
+};


### PR DESCRIPTION
- storybook起動
```
npm run storybook
```
http://localhost:6006/


<img width="1419" alt="スクリーンショット 2024-12-28 2 30 08" src="https://github.com/user-attachments/assets/d316fe11-304a-408e-89de-16d6067c4f81" />
